### PR TITLE
Preload Fonts

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "eslint-plugin-react": "^7.18.0",
     "eslint-plugin-react-hooks": "^1.7.0",
     "prettier": "^1.19.1",
+    "prop-types": "^15.7.2",
     "redux-devtools": "^3.5.0"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,9 @@
 
 <head>
   <meta charset="utf-8" />
+
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css?family=Montserrat:400,700&display=swap">
+
   <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />


### PR DESCRIPTION
When preloading fonts, the browser will start loading font files in parallel instead of waiting to parse the CSS file for `@import url('https://fonts.googleapis.com/css?family=Montserrat:400,700&display=swap');`